### PR TITLE
Batch uses today if no timestamp present + check if file to import exists

### DIFF
--- a/batch/parsers/xUnitParser.js
+++ b/batch/parsers/xUnitParser.js
@@ -9,6 +9,10 @@ class XUnitParser {
 		this.configuration = configuration;
 	}
 
+	get now() {
+		return new Date();
+	}
+
 	readFile(xUnitFilePath, callback) {
 		fs.readFile(xUnitFilePath, function (err, data) {
 			callback(err, data.toString());
@@ -51,9 +55,12 @@ class XUnitParser {
 									name: parsedData.suite.name,
 									tests: parsedData.suite.summary.tests,
 									failures: parsedData.suite.summary.failures,
-									timestamp: `${parsedData.suite.timestamp}`,
+									timestamp: `${parsedData.suite.timestamp || self.now.getTime()}`,
 									testCases: testCases
 								};
+								if(!parsedData.suite.timestamp) {
+									console.log('Warning : No timestamp was provided for specified test suite, using current system date.');
+								}
 								callback(null, testSuite);
 							} else {
 								callback(null, null);

--- a/batch/runner.js
+++ b/batch/runner.js
@@ -1,19 +1,29 @@
 import {TestResultsCollector} from './testResultsCollector';
 import configuration from '../ludwig-conf';
+import fs from 'fs';
 
 const collector = new TestResultsCollector(configuration);
 
-if (process.argv[2]) {
-	collector.saveFromXUnitData(process.argv[2], (err, data) => {
-		if (err) {
-			console.error('Something wrong happened');
-			console.error(err);
-			process.exit(1);
+const filePath = process.argv[2];
+if (filePath) {
+	fs.stat(filePath, (err, stat)  => {
+		if(!err && stat.isFile()) {
+			collector.saveFromXUnitData(filePath, (err, data) => {
+				if (err) {
+					console.error('Something wrong happened');
+					console.error(err);
+					process.exit(1);
+				} else {
+					console.log('Data inserted!');
+					process.exit(0);
+				}
+			});
 		} else {
-			console.log('Data inserted!');
-			process.exit(0);
+			console.error(`Path specified does not point to a file (${filePath})`);
+			process.exit(1);
 		}
 	});
+
 } else {
 	console.log('You need to specify a file');
 	console.log('Usage : babel-node runner.js <xunit_report.xml>');

--- a/test/batch/parsers/xUnitParserSpec.js
+++ b/test/batch/parsers/xUnitParserSpec.js
@@ -53,6 +53,11 @@ describe('XUnit Parser', () => {
 		//setup
 		sinon.stub(xUnitParser, 'readFile').yields(null, '<testsuite name="Test Suite" tests="2" failures="0" errors="0" skipped="0" timestamp="Tue, 08 Mar 2016 09:07:06 GMT" time="0.103"><testcase classname="" name="Test Case" time="0.02"><randomElement>not a failure</randomElement></testcase><testcase classname="" name="Test Case 2" time="0.02"/><system-out></system-out><system-err></system-err></testsuite>');
 		const callback = sinon.spy();
+		sinon.stub(xUnitParser, 'now', {
+			get: () => {
+				return 'Tue, 05 Apr 2016 09:16:33 GMT';
+			}
+		});
 		//action
 		xUnitParser.parse('./filename.xunitreport', callback);
 		//assert
@@ -78,6 +83,25 @@ describe('XUnit Parser', () => {
 					timestamp: '1457428026000'
 				} ]
 		});
+	});
+
+	it('should use the current date if no timestamp is found in the test suite', function() {
+		//setup
+		sinon.stub(xUnitParser, 'readFile').yields(null, '<testsuite name="Test Suite" tests="2" failures="0" errors="0" skipped="0" time="0.103"><testcase classname="" name="Test Case" time="0.02"><randomElement>not a failure</randomElement></testcase><testcase classname="" name="Test Case 2" time="0.02"/><system-out></system-out><system-err></system-err></testsuite>');
+		const callback = sinon.spy();
+		sinon.stub(xUnitParser, 'now', {
+			get: () => {
+				const mockedDate = new Date();
+				mockedDate.setTime(1459847793847);
+				return mockedDate;
+			}
+		});
+		//action
+		xUnitParser.parse('./filename.xunitreport', callback);
+		//assert
+		assert.equal(callback.calledOnce, true);
+		assert.equal(callback.getCall(0).args[0], null);
+		assert.equal(callback.getCall(0).args[1].timestamp, '1459847793847');
 	});
 
 	it('should return a testSuite with one failed test included in it if xUnitReport contains one test case, failures property must be read from testSuite attributes', () => {


### PR DESCRIPTION
If the parsed xunit file cannot find a timestamp for the testsuite parsed, it is now replaced by the current date (and the user is warned by a console message)
+
batch runner checks if provided file exists and displays a proper error message if not