### PR TITLE
Fix #31 : Unified configuration naming across widget & server

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,10 +90,10 @@ Le fichier de configuration utilisé par l'application se trouve à la racine. I
 
 Un fichier exemple `ludwig-conf-sample.js` est présent à la racine du projet, renommé en `ludwig-conf.js` et édité pour y mettre les informations correspondant à votre dépôt / votre base de données il devrait permettre à votre instance de se lancer et de communiquer avec les APIs GitHub.
 
-* `repository`: Le dépôt GitHub où sont versionnés les tests (sous la forme `<utilisateur>/<nom du dépôt>`
+* `repo`: Le dépôt GitHub où sont versionnés les tests (sous la forme `<utilisateur>/<nom du dépôt>`
 * `acceptedTestsLocation`: Le chemin dans le dép&ot GitHub où trouver le répertoire contenant les tests (ex: `/treee/master/tests` si le répertoire `tests` est à la racine du dépôt et que c'est celui que l'on souhaite utiliser)
 * `github`:
-    * `branchToCreatePullRequestsFor`: La branche de travail (par défaut : master)
+    * `branch`: La branche de travail (par défaut : master)
     * `authenticationCallback`: L'URL de callback que GitHub doit appeler lors d'une authentification
 * `mongo` (cette section correspond à ce que l'on trouve dans la documentation de [mongoose](http://mongoosejs.com/docs/api.html#index_Mongoose-connect)):
     * `uri`: L'URI de connexion 

--- a/batch/parsers/xUnitParser.js
+++ b/batch/parsers/xUnitParser.js
@@ -24,7 +24,7 @@ class XUnitParser {
 			name: testCaseXMLObject.name,
 			status: 'ok',
 			timestamp: `${parsedData.suite.timestamp}`,
-			location:`${GITHUB_REPO_URL}${this.configuration.repository}${this.configuration.acceptedTestsLocation}/${testCaseXMLObject.classname}`,
+			location:`${GITHUB_REPO_URL}${this.configuration.repo}${this.configuration.acceptedTestsLocation}/${testCaseXMLObject.classname}`,
 			time:time(testCaseXMLObject.time)
 		};
 		if(testCaseXMLObject.failure) {

--- a/helpers/githubHelper.js
+++ b/helpers/githubHelper.js
@@ -7,10 +7,10 @@ const GITHUB_API_REPO_URL_PREFIX = 'https://api.github.com/repos/';
 class GithubHelper {
 	constructor() {
 		this.githubConfig = {
-			referencesEndpoint: `${GITHUB_API_REPO_URL_PREFIX}${configuration.repository}/git/refs`,
-			createContent: `${GITHUB_API_REPO_URL_PREFIX}${configuration.repository}/contents/`,
-			createPullRequest: `${GITHUB_API_REPO_URL_PREFIX}${configuration.repository}/pulls`,
-			repository:configuration.repository
+			referencesEndpoint: `${GITHUB_API_REPO_URL_PREFIX}${configuration.repo}/git/refs`,
+			createContent: `${GITHUB_API_REPO_URL_PREFIX}${configuration.repo}/contents/`,
+			createPullRequest: `${GITHUB_API_REPO_URL_PREFIX}${configuration.repo}/pulls`,
+			repository:configuration.repo
 		};
 	}
 
@@ -36,7 +36,7 @@ class GithubHelper {
 		return new Promise( (resolve, reject) => {
 			this.agent
 				.post(this.config.createPullRequest)
-				.send(this.createPullRequestRequestBody(head, title, body, configuration.github.branchToCreatePullRequestsFor))
+				.send(this.createPullRequestRequestBody(head, title, body, configuration.github.branch))
 				.set('Authorization', `token ${accessToken}`)
 				.end((err, createPRResult) => {
 					if(err) {

--- a/ludwig-conf-sample.js
+++ b/ludwig-conf-sample.js
@@ -1,8 +1,8 @@
 module.exports = {
-	repository: 'github-user/repository',
+	repo: 'github-user/repository',
 	acceptedTestsLocation:'/tree/master/tests',
 	github:{
-		branchToCreatePullRequestsFor:'<commit sha1 reference from master to branch from>',
+		branch:'<commit sha1 reference from master to branch from>',
 		authenticationCallback:'http://authentication.callback.url/for/github/login'
 	},
 	mongo:{

--- a/routers/main.js
+++ b/routers/main.js
@@ -50,7 +50,7 @@ router.get('/createSuggestion',
 
 router.get('/github_callback', passport.authenticate('github', {failureRedirect: '/authKO'}), (req, res) => {
 	const suggestionsController = new SuggestionsController();
-	suggestionsController.createPullRequest(process.env.npm_config_ludwig_accessToken, req.session.title, req.session.description, req.session.state, res, config.github.branchToCreatePullRequestsFor);
+	suggestionsController.createPullRequest(process.env.npm_config_ludwig_accessToken, req.session.title, req.session.description, req.session.state, res, config.github.branch);
 });
 
 router.get('/', (req, res) => {

--- a/test/batch/parsers/xUnitParserSpec.js
+++ b/test/batch/parsers/xUnitParserSpec.js
@@ -10,7 +10,7 @@ describe('XUnit Parser', () => {
 		xUnitParser = new XUnitParser({
 			repoUrl: 'https://github.com/user/repo',
 			acceptedTestsLocation: '/tree/master/tests',
-			repository:'user/repo'
+			repo:'user/repo'
 		});
 	});
 


### PR DESCRIPTION
acceptedTestsLocation → compute from branch left out right now as it has been fixed in a separate branch (batch_retrieves_initial_file_author, PR should be created today)