### PR TITLE
Use an empty string in widget if template is not configured

### DIFF
--- a/js/ludwig.js
+++ b/js/ludwig.js
@@ -9,7 +9,7 @@ class Ludwig {
 		}
 		this.repo = configuration.repo;
 		this.branch = configuration.branch || 'master';
-		this.template = configuration.template;
+		this.template = configuration.template || '';
 		this.prefix = configuration.prefix;
 		this.ludwigCreateSuggestionURL = configuration.ludwigCreateSuggestionURL;
 		this.expectedTemplate = configuration.expectedTemplate || '';

--- a/test/widget/ludwigSpec.js
+++ b/test/widget/ludwigSpec.js
@@ -39,6 +39,14 @@ describe('Widget : Sugestion link retrieval', () => {
 				assert.equal(error.message, '"repo" field in configuration is mandatory');
 			}
 		});
+
+		it('should set the template to an empty string if configuration.template is not set', () => {
+			//setup
+			//action
+			ludwig = new Ludwig({repo:'foobar'});
+			//assert
+			assert.deepEqual(ludwig.template, '');
+		});
 	});
 
 	describe('generateSuggestionName', () => {
@@ -301,7 +309,7 @@ describe('Widget : Sugestion link retrieval', () => {
 			assert.deepEqual(actual, {
 				title:'my title',
 				description:'my description',
-				state:'undefined\r\n{\n\t"current": "state"\n}\r\n{\n\t"expected": "state"\n}'
+				state:'\r\n{\n\t"current": "state"\n}\r\n{\n\t"expected": "state"\n}'
 			});
 		});
 


### PR DESCRIPTION
If the developer choses not to specify a template in the widget
configuration, it is replaced by an empty string to avoid output-ing
"undefined"