### PR TITLE
Add the possibility to filter tests by their names & status

### DIFF
--- a/controllers/listTestsController.js
+++ b/controllers/listTestsController.js
@@ -22,7 +22,11 @@ module.exports.showLatestTestSuite = function (customUserFilter, callback) {
 
 module.exports.authenticateToFilterMyTests = function (res, next) {
 	if (res.req.session.passport) {
-		return res.redirect('/listTests?filter=mine');
+		let redirectTarget = '/listTests?filter=mine';
+		if (res.req.query.testNameFilter) {
+			redirectTarget+=`&testNameFilter=${res.req.query.testNameFilter}`;
+		}
+		return res.redirect(redirectTarget);
 	}
 	next();
 };

--- a/guiUtils/guiUtils.js
+++ b/guiUtils/guiUtils.js
@@ -1,0 +1,26 @@
+function filterByTestName(search, testName) {
+	if (testName) {
+		if (search) {
+			if (!search.match(/.*testNameFilter=.*/)) {
+				return search+='&testNameFilter='+testName;
+			} else {
+				return search.replace(/testNameFilter=[^&]*/, 'testNameFilter='+testName);
+			}
+		} else {
+			return '?testNameFilter='+testName;
+		}
+	}
+	return null;
+}
+
+module.exports.filterByTestName = filterByTestName;
+
+function filterByMine(location) {
+	if (location.search && !location.search.includes('filter=mine')) {
+		return `${location.pathname}${location.search}&filter=mine`;
+	} else {
+		return '/listTestsConnected?filter=mine';
+	}
+}
+
+module.exports.filterByMine = filterByMine;

--- a/guiUtils/guiUtilsWrapper.js
+++ b/guiUtils/guiUtilsWrapper.js
@@ -1,0 +1,4 @@
+'use strict';
+import guiUtils from './guiUtils';
+
+window.guiUtils = guiUtils;

--- a/package.json
+++ b/package.json
@@ -53,15 +53,17 @@
   "files": [
     "controllers",
     "dist/ludwig.js",
+    "dist/guiUtils.js",
     "helpers",
     "routers",
     "views",
     "server.js",
     "scripts",
+    "webpack.config.server.js",
     "webpack.config.js"
   ],
   "scripts": {
-    "build": "mkdir -p dist && cp -r node_modules/bootstrap/dist ./dist/bootstrap && cp -r ./views/css/ ./dist/ && webpack",
+    "build": "mkdir -p dist && cp -r node_modules/bootstrap/dist ./dist/bootstrap && cp -r ./views/css/ ./dist/ && webpack && webpack --config webpack.config.server.js",
     "prepublish": "npm run build",
     "start": "babel-node server.js",
     "test": "mocha --compilers js:babel-core/register --recursive ./test/",

--- a/routers/main.js
+++ b/routers/main.js
@@ -68,6 +68,11 @@ router.get('/listTests', (req, res) => {
 	if (myTestsOnly) {
 		customUserFilter = ListTestsController.buildTestFilterForUser(req.session.passport.user._json);
 	}
+
+	if (req.query['testNameFilter']) {
+		customUserFilter.testNameFilter = req.query['testNameFilter'];
+	}
+
 	ListTestsController.showLatestTestSuite(customUserFilter, (err, renderParams) => {
 		if (err) {
 			res.render('ko');

--- a/test/controllers/listTestsControllerSpec.js
+++ b/test/controllers/listTestsControllerSpec.js
@@ -49,7 +49,7 @@ describe('ListTestsController', () => {
 	describe('authenticateToFilterMyTests', () => {
 		it('should redirect to "/listTests?filter=mine" if passport session data is defined', () => {
 			//setup
-			const res = {redirect:sinon.spy(), req:{session:{passport:{}}}};
+			const res = {redirect:sinon.spy(), req:{query:{}, session:{passport:{}}}};
 			//action
 			ListTestsController.authenticateToFilterMyTests(res);
 			//assert
@@ -66,6 +66,18 @@ describe('ListTestsController', () => {
 			//assert
 			assert.equal(res.redirect.called, false);
 			assert.equal(next.calledOnce, true);
+		});
+
+		it('should include the testNameFilter query param if it is set in incoming query', () => {
+			//setup
+			const next = sinon.spy();
+			const res = {redirect:sinon.spy(), req:{session:{passport:{}}, query:{testNameFilter:'foo'}}};
+			//action
+			ListTestsController.authenticateToFilterMyTests(res, next);
+			//assert
+			assert.equal(res.redirect.calledOnce, true);
+			assert.equal(res.redirect.getCall(0).args[0], '/listTests?filter=mine&testNameFilter=foo');
+			assert.equal(next.called, false);
 		});
 	});
 

--- a/test/serverGUI/guiUtilsSpec.js
+++ b/test/serverGUI/guiUtilsSpec.js
@@ -1,0 +1,66 @@
+/*global describe it*/
+import guiUtils from '../../guiUtils/guiUtils';
+import {assert} from 'chai';
+
+describe('Server GUI utils', () => {
+	describe('filterByTestName', () => {
+		it('should return null if testName is empty', () => {
+			//setup
+			//action
+			const actual = guiUtils.filterByTestName(null, '');
+			//assert
+			assert.equal(actual, null);
+		});
+
+		it('should return "?testNameFilter=foobar" if testName is "foobar" and there are no other filters defined', () => {
+			//setup
+			//action
+			const actual = guiUtils.filterByTestName(null, 'foobar');
+			//assert
+			assert.equal(actual, '?testNameFilter=foobar');
+		});
+
+		it('should append "&testNameFilter=foobar" if window.location.search is not empty', () => {
+			//setup
+			//action
+			const actual = guiUtils.filterByTestName('?test=1', 'foobar');
+			//assert
+			assert.equal(actual, '?test=1&testNameFilter=foobar');
+		});
+
+		it('should replace testNameFilter value if it is already set', () => {
+			//setup
+			//action
+			const actual = guiUtils.filterByTestName('?testNameFilter=foobar&filter=mine', 'baz');
+			//assert
+			assert.equal(actual, '?testNameFilter=baz&filter=mine');
+		});
+	});
+
+	describe('filterByMine', () => {
+		it('should add the "mine" filter if no other filter is active', () => {
+			//setup
+			//action
+			const actual = guiUtils.filterByMine({pathname:'/listTestsConnected', search:''});
+			//assert
+			assert.equal(actual, '/listTestsConnected?filter=mine');
+		});
+		it('should append the "mine" filter at the end of an existing search', () => {
+			//setup
+
+			//action
+			const actual = guiUtils.filterByMine({pathname:'/listTestsConnected', search:'?testNameFilter=foo'});
+			//assert
+			assert.equal(actual, '/listTestsConnected?testNameFilter=foo&filter=mine');
+		});
+		it('should not append the "mine" filter multiple times if it already exists', () => {
+			//setup
+
+			//action
+			const actual = guiUtils.filterByMine({pathname:'/listTestsConnected', search:'?filter=mine'});
+			//assert
+			assert.equal(actual, '/listTestsConnected?filter=mine');
+		});
+	});
+});
+

--- a/views/listTests.ejs
+++ b/views/listTests.ejs
@@ -4,6 +4,30 @@
     <title>Liste des tests de l'application</title>
     <link href="bootstrap/css/bootstrap.min.css" rel="stylesheet"/>
     <link href="css/ludwig.css" rel="stylesheet"/>
+    <script type="text/javascript" src="/guiUtils.js">
+    </script>
+    <script type="text/javascript">
+        function filterByTestName(){
+            var testNameFilter =  document.getElementById('testNameFilter').value;
+            if (testNameFilter) {
+                window.location.search = guiUtils.filterByTestName(window.location.search, testNameFilter);
+            }
+        }
+        function resetTestNameFilter(){
+            document.getElementById('testNameFilter').value = '';
+            window.location.search = window.location.search.replace(/testNameFilter=[^&]*/, '');
+        }
+
+        function filterMyTests(){
+            //console.log(guiUtils.filterByMine(window.location));
+            window.location = guiUtils.filterByMine(window.location);
+            //window.location = '/listTestsConnected';
+        }
+
+        function filterAllTests(){
+            window.location = '/listTests';
+        }
+    </script>
 </head>
 <body>
 
@@ -17,14 +41,25 @@
             <div class="panel-heading"><div style="width:100%">Les tests pour la campagne "<%= testSuite.name %>" réalisés
                 le <%= formattedTimestamp %></div>
 
-                <%if(!mine){%>
-                <button class="btn btn-default" onclick="window.location = '/listTestsConnected'">Voir seulement mes tests (login GitHub requis)</button>
-                <%} else {%>
-                <button class="btn btn-default" onclick="window.location = '/listTests'">Voir tous les tests</button>
-                <%}%>
+                <div class="row">
+                    <div class="col-sm-6">
+                        <%if(!mine){%>
+                        <button class="btn btn-default" onclick="filterMyTests()">Voir seulement mes tests (login GitHub requis)</button>
+                        <%} else {%>
+                        <button class="btn btn-default" onclick="filterAllTests()">Voir tous les tests</button>
+                        <%}%>
+                    </div>
+
+                    <div class="col-sm-6">
+                        <button class="btn btn-default pull-right" style="margin-right:25px;" onclick="filterByTestName()">Filtrer par nom de test</button>
+                        <input type="text" class="pull-right" name="testNameFilter" id="testNameFilter" placeholder="nom ou partie du nom d'un test"/>
+                        <button class="btn btn-default pull-right" style="position:absolute;top:0;right:0;width:35px;" onclick="resetTestNameFilter()">X</button>
+                    </div>
+                </div>
+
             </div>
             <div class="panel-body"><p>
-                    Nombre total de tests : <%= testSuite.testCases.length %>
+                    Nombre de tests (filtrés) : <%= testSuite.testCases.length %>
                 </p>
                 <p>
                     Nombre d'échecs : <%= testSuite.failures %>

--- a/webpack.config.server.js
+++ b/webpack.config.server.js
@@ -1,0 +1,18 @@
+module.exports = {
+	entry: './guiUtils/guiUtilsWrapper.js',
+	output: {
+		filename: './dist/guiUtils.js'
+	},
+	module:{
+		loaders: [
+			{
+				test: /\.js?$/,
+				exclude: /(node_modules|bower_components)/,
+				loader: 'babel',
+				query: {
+					presets: [ 'es2015' ]
+				}
+			}
+		]
+	}
+};


### PR DESCRIPTION
- Filter is case insensitive (both ways, filter and test case name)
- It combines w/ profile data filter (i.e: if both are set then a test
  must match both to be added in the set of filtered test cases)
- There is also a status filter (get ALL, OK, or KO tests)
- All filters should combine together
