### PR TITLE
Fix #39 Widget asks for a domain name not a path

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Le widget s'instancie avec en unique paramètre un objet contenant les informati
 * `branch` : branche dans laquelle créer des nouvelles demandes et consulter la liste de tests.
 * `template` : contenu par défaut du fichier créé avec la suggestion.
 * `prefix` : préfixe du fichier qui sera créé lors de la suggestion.
-* `ludwigCreateSuggestionURL` : l'URL Ludwig à joindre pour créer une suggestion en passant par les APIs authentifiées GitHub.
+* `ludwigCreateSuggestionDomain` : le domaine pour joindre Ludwig et créer une suggestion en passant par les APIs authentifiées GitHub.
 
 ### Ajouter le widget
 

--- a/js/ludwig.js
+++ b/js/ludwig.js
@@ -11,7 +11,13 @@ class Ludwig {
 		this.branch = configuration.branch || 'master';
 		this.template = configuration.template;
 		this.prefix = configuration.prefix;
-		this.ludwigCreateSuggestionURL = configuration.ludwigCreateSuggestionURL;
+		const suggestionDomain = configuration.ludwigCreateSuggestionDomain? configuration.ludwigCreateSuggestionDomain : 'http://localhost:3000';
+		if (suggestionDomain.match(/\/createSuggestion/)) {
+			this.ludwigCreateSuggestionURL = suggestionDomain;
+
+		} else {
+			this.ludwigCreateSuggestionURL = `${suggestionDomain}/createSuggestion`;
+		}
 		this.expectedTemplate = configuration.expectedTemplate || '';
 	}
 

--- a/test/widget/ludwigSpec.js
+++ b/test/widget/ludwigSpec.js
@@ -39,6 +39,20 @@ describe('Widget : Sugestion link retrieval', () => {
 				assert.equal(error.message, '"repo" field in configuration is mandatory');
 			}
 		});
+
+		it('should append "/createSuggestion" to the configuration.ludwigCreateSuggestionDomain', () => {
+			//setup / action
+			ludwig = new Ludwig({repo:'foobar', ludwigCreateSuggestionDomain:'specifiedDomain'});
+			//assert
+			assert.equal(ludwig.ludwigCreateSuggestionURL, 'specifiedDomain/createSuggestion');
+		});
+
+		it('should not append "/createSuggestion" to the configuration.ludwigCreateSuggestionDomain if it already contains that suffix', () => {
+			//setup / action
+			ludwig = new Ludwig({repo:'foobar', ludwigCreateSuggestionDomain:'specifiedDomain/createSuggestion'});
+			//assert
+			assert.equal(ludwig.ludwigCreateSuggestionURL, 'specifiedDomain/createSuggestion');
+		});
 	});
 
 	describe('generateSuggestionName', () => {

--- a/views/test.ejs
+++ b/views/test.ejs
@@ -13,7 +13,7 @@
         template: 'some+basic+template\r\nwith\r\n\tmultiple indented lines\r\n===============================================================================================================',
         prefix: 'test-ludwig',
         expectedTemplate: '{\r\n\t"data":"123",\r\n\t"toBe":{\r\n\t\t"used":1, \r\n\t\t"as":"template for expected state"\r\n\t}\r\n}',
-        ludwigCreateSuggestionURL: 'http://localhost:3000/createSuggestion'
+        ludwigCreateSuggestionDomain: 'http://localhost:3000'
     }
 
     var ludwig = new Ludwig(configuration)


### PR DESCRIPTION
- Changed conf so that the conf asked limits itself to the relevant part
  (domain)
- if /createSuggestion suffix is provided, even though not necessary
  anymore, it's not appended again
- updated documentation to fit new behavior
- added a default domain value that is set to 'http://localhost:3000'
